### PR TITLE
Fix details

### DIFF
--- a/src/components/CarouselItem.js
+++ b/src/components/CarouselItem.js
@@ -1,15 +1,17 @@
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import carImageSmall from '../images/car-small.png';
 
 const CarouselItem = ({ car }) => {
-  const { make, model, id } = car;
+  const {
+    id, make, model, image,
+  } = car;
+
   return (
     <Link to={`/cars/${id}`}>
       <div className="hover:opacity-60">
         <div className="bg-amber-500 w-52 h-52 rounded-full mx-auto relative mb-10">
           <div className="absolute -left-3/4 top-1/2 translate-x-1/2 -translate-y-1/2 w-[130%]">
-            <img src={carImageSmall} alt="car" />
+            <img src={image} alt="car" />
           </div>
         </div>
         <div className="max-w-[240px] mx-auto">

--- a/src/components/CarouselItem.js
+++ b/src/components/CarouselItem.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import carImageSmall from '../images/car-small.png';
 
 const CarouselItem = ({ car }) => {
-  const { make, model } = car;
+  const { make, model, id } = car;
   return (
-    <Link to="/cars/1">
-      <div>
+    <Link to={`/cars/${id}`}>
+      <div className="hover:opacity-60">
         <div className="bg-amber-500 w-52 h-52 rounded-full mx-auto relative mb-10">
           <div className="absolute -left-3/4 top-1/2 translate-x-1/2 -translate-y-1/2 w-[130%]">
             <img src={carImageSmall} alt="car" />


### PR DESCRIPTION
## Hi team!
### Here's a quick overview of this PR:

- I changed `Carouseltem` to work with the data from the API:
  - Links now point to corresponding IDs.
  - It uses the images, coming from the API:
<img width="1440" alt="Screenshot 2022-05-11 at 3 53 40 pm" src="https://user-images.githubusercontent.com/45717589/167822967-db681387-e6a2-47f3-9ce1-a2a314cf9052.png">
 